### PR TITLE
Exclude the force full width from search queries

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -67,7 +67,7 @@ function genesis_portfolio_template_chooser( $template ) {
 	// Post ID
 	$post_id = get_the_ID();
 
-	if ( get_post_type( $post_id ) == 'portfolio' || is_post_type_archive( 'portfolio' ) || is_tax( 'portfolio-type' ) ) {
+	if ( ! is_search() && get_post_type( $post_id ) == 'portfolio' || is_post_type_archive( 'portfolio' ) || is_tax( 'portfolio-type' ) ) {
 		require_once( GENESIS_PORTFOLIO_LIB . 'functions.php' );
 	}
 	if ( is_single() && get_post_type( $post_id ) == 'portfolio' ) {


### PR DESCRIPTION
Whether the search includes a post from the portfolio CPT or not, the code on line 70 interferes with any ``genesis_pre_get_option_site_layout`` filter on the search.php page giving the layout full width even when the theme dev has another layout in mind.