### PR TITLE
Remove default parameter for `$defaults`

### DIFF
--- a/genesis-portfolio-pro.php
+++ b/genesis-portfolio-pro.php
@@ -128,7 +128,7 @@ function genesis_portfolio_archive_setting_sanitization() {
  * @param  string $post_type The post type to filter settings for.
  * @return array
  */
-function genesis_portfolio_archive_setting_defaults( $defaults = array(), $post_type ) {
+function genesis_portfolio_archive_setting_defaults( $defaults, $post_type ) {
 	if ( 'portfolio' === $post_type ) {
 		$defaults                   = (array) $defaults;
 		$defaults['posts_per_page'] = get_option( 'posts_per_page' );


### PR DESCRIPTION
* Jen found a Deprecated notice from this on PHP `8.0` and WP `6.0`:
> Deprecated: Optional parameter  declared before required parameter  is implicitly treated as a required parameter in
genesis-portfolio-pro/genesis-portfolio-pro.php on line 131

<img width="1009" alt="Screen Shot 2022-05-16 at 12 13 47 PM" src="https://user-images.githubusercontent.com/4063887/168647332-9ff6413a-ce7b-44ec-be40-ee843b1804e0.png">

* `genesis_portfolio_archive_setting_defaults()` is a [filter callback](https://github.com/studiopress/genesis/blob/8a6c3750e4817cdbd15c2ce7e9b6c5dfb5894e90/lib/classes/class-genesis-admin-cpt-archive-settings.php#L77)
* So the first argument shouldn't need a default, as that would mean some other filter callback mistakenly didn't return anything




<!-- A short but detailed summary of the changes. -->

<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Run PHP `8.1` (or maybe `8.0`) and WP `6.0`
1. Activate this plugin (no build steps like `npm run dev` needed)
2. Go to `/wp-admin/plugins.php`, if you're not there already
3. Expected: There's no PHP notice at the top of the page

### Documentation
No documentation required. 
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Remove a default argument for `$defaults`

